### PR TITLE
Update: 토큰 발급&인증 관련 오류 수정, 리프레쉬 토큰 발급 

### DIFF
--- a/ormConfig.ts
+++ b/ormConfig.ts
@@ -15,7 +15,7 @@ const config: TypeOrmModuleOptions = {
   entities: [User, Token, Post],
   autoLoadEntities: true,
   charset: 'utf8mb4',
-  synchronize: true,
+  synchronize: false,
   logging: true,
   migrationsRun: false,
 };

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,18 +1,19 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { AuthDto } from './dto/auth.dto';
+import { SignUpDto } from './dto/sign-up.dto';
 import { AuthService } from './auth.service';
+import { SignInDto } from './dto/sign-in.dto';
 
 @Controller('/sns/auth')
 export class AuthController {
   constructor(private readonly service: AuthService) {}
 
   @Post('/sign-up')
-  async signUp(@Body() authDto: AuthDto) {
-    return await this.service.signUp(authDto);
+  async signUp(@Body() signUpDto: SignUpDto) {
+    return await this.service.signUp(signUpDto);
   }
 
   @Post('/sign-in')
-  async signIn(@Body() authDto: AuthDto) {
-    return await this.service.signIn(authDto);
+  async signIn(@Body() signInDto: SignInDto) {
+    return await this.service.signIn(signInDto);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,11 +6,12 @@ import { User } from 'src/entities/User';
 import { JwtService } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './jwt.strategy';
+import { Token } from '../entities/Token';
 
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, Token]),
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,28 +3,17 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entities/User';
-import { JwtModule } from '@nestjs/jwt';
+import { JwtService } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './jwt.strategy';
-import { ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.registerAsync({
-      //.env 파일 읽어올때까지 secret등록 작업 유예
-      inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        secret: process.env.JWT_ACCESS_TOKEN_SECRET,
-        signOptions: {
-          expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
-        },
-      }),
-    }),
     TypeOrmModule.forFeature([User]),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, JwtService],
   exports: [JwtStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -33,4 +33,12 @@ export class AuthService {
       throw new UnauthorizedException('로그인을 실패했습니다.');
     }
   }
+
+  async makeAccessToken(userId: number) {
+    const payload = { userId };
+    return await this.jwtService.sign(payload, {
+      secret: process.env.JWT_ACCESS_TOKEN_SECRET,
+      expiresIn: `${process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME}h`,
+    });
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,12 +5,14 @@ import { User } from 'src/entities/User';
 import { Repository } from 'typeorm';
 import { SignUpDto } from './dto/sign-up.dto';
 import { SignInDto } from './dto/sign-in.dto';
+import { Token } from '../entities/Token';
 
 @Injectable()
 export class AuthService {
   constructor(
     private jwtService: JwtService,
     @InjectRepository(User) private repository: Repository<User>,
+    @InjectRepository(Token) private tokenRepository: Repository<Token>,
   ) {}
 
   async signUp(signUpDto: SignUpDto) {
@@ -26,19 +28,77 @@ export class AuthService {
     });
 
     if (user) {
-      const accessToken = await this.makeAccessToken(user.id);
-      const refreshToken = await this.makeRefreshToken(user.id);
+      const accessToken = await this.setAccessToken(user.id);
+      const refreshToken = await this.setRefreshToken(user);
       return { accessToken, refreshToken };
     } else {
       throw new UnauthorizedException('로그인을 실패했습니다.');
     }
   }
 
-  async makeAccessToken(userId: number) {
+  /**
+   * 로그인시 새로운 액세스 토큰 생성 함수
+   */
+  async setAccessToken(userId: number) {
     const payload = { userId };
     return await this.jwtService.sign(payload, {
       secret: process.env.JWT_ACCESS_TOKEN_SECRET,
       expiresIn: `${process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME}h`,
     });
+  }
+
+  /**
+   * 리프레쉬 토큰 새로 생성 또는 유효기간 연장 처리 함수
+   */
+  async setRefreshToken(user: User) {
+    const userId = user.id;
+    const payload = { userId };
+    const refreshToken = await this.jwtService.sign(payload, {
+      secret: process.env.JWT_REFRESH_TOKEN_SECRET,
+      expiresIn: `${process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME}d`,
+    });
+
+    const data = await this.tokenRepository
+      .createQueryBuilder('token')
+      .leftJoinAndSelect('token.user', 'user')
+      .where('token.user = :uid', { uid: userId })
+      .getOne();
+
+    if (!data) {
+      // 리프레쉬 토큰이 없는 경우 새로 발급
+      const newToken = this.tokenRepository.create({
+        user: user,
+        token: refreshToken,
+        expiredAt: this.addExpireDays(
+          new Date(),
+          parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME),
+        ),
+      });
+
+      await this.tokenRepository.save(newToken);
+    } else {
+      // 리프레쉬 토큰이 있는 경우 유효기간 연장
+      await this.tokenRepository
+        .createQueryBuilder()
+        .update(Token)
+        .set({
+          expiredAt: this.addExpireDays(
+            data.expiredAt,
+            parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME),
+          ),
+        })
+        .where('token.id = :id', { id: data.id })
+        .execute();
+    }
+
+    return refreshToken;
+  }
+
+  /**
+   * 리프레쉬 토큰 유효기간 처리 함수
+   */
+  addExpireDays(date: Date, plusDays: number) {
+    date.setDate(date.getDate() + plusDays);
+    return date;
   }
 }

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,4 +1,5 @@
 export class AuthDto {
   email: string;
   pwd: string;
+  nickname: string;
 }

--- a/src/auth/dto/sign-in.dto.ts
+++ b/src/auth/dto/sign-in.dto.ts
@@ -1,0 +1,4 @@
+export class SignInDto {
+  email: string;
+  pwd: string;
+}

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -1,4 +1,4 @@
-export class AuthDto {
+export class SignUpDto {
   email: string;
   pwd: string;
   nickname: string;

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -19,9 +19,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload) {
-    const { email } = payload;
+    const { userId } = payload;
     const user: User = await this.repository.findOneBy({
-      email: email,
+      id: userId,
     });
 
     if (!user) {

--- a/src/entities/Token.ts
+++ b/src/entities/Token.ts
@@ -1,4 +1,11 @@
-import { Entity, Column, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { User } from './User';
 
 @Entity()
@@ -15,9 +22,9 @@ export class Token {
   @Column({ name: 'expired_at' })
   expiredAt: Date;
 
-  @Column({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
-  @Column({ name: 'updated_at' })
+  @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -20,7 +20,7 @@ export class User {
   @Column()
   pwd: string;
 
-  @Column()
+  @Column({ unique: true })
   nickname: string;
 
   @CreateDateColumn({ name: 'created_at' })


### PR DESCRIPTION
## 설명
- 아이디를 다르게해도 토큰 발급시 포함된 유저정보가 동일함 
-> payload에 userId 담는 부분에서 에러가 있는것으로 확인하고 해결함
- 리프레쉬 토큰 발급 완료

## 할일
- [x] 토큰 발급 에러 수정
- [x] 리프레쉬 토큰 발급

## 일정
- 현재 액세스 토큰의 경우 유효기간이 지나면 자동으로 jwt에서 401에러를 반환중. 나중에 리프레쉬 토큰으로 처리 필요해보임.