### PR TITLE
Update: 게시글 관련 세부기능 추가

### DIFF
--- a/ormConfig.ts
+++ b/ormConfig.ts
@@ -3,6 +3,7 @@ import * as dotenv from 'dotenv';
 import { Post } from 'src/entities/Post';
 import { Token } from 'src/entities/Token';
 import { User } from 'src/entities/User';
+import { Like } from './src/entities/Like';
 
 dotenv.config();
 const config: TypeOrmModuleOptions = {
@@ -12,7 +13,7 @@ const config: TypeOrmModuleOptions = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE,
-  entities: [User, Token, Post],
+  entities: [User, Token, Post, Like],
   autoLoadEntities: true,
   charset: 'utf8mb4',
   synchronize: false,

--- a/src/entities/Like.ts
+++ b/src/entities/Like.ts
@@ -1,0 +1,15 @@
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Post } from './Post';
+import { User } from './User';
+
+@Entity()
+export class Like {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Post, (post) => post.like)
+  post: Post;
+
+  @ManyToOne(() => User, (user) => user.like)
+  user: User;
+}

--- a/src/entities/Post.ts
+++ b/src/entities/Post.ts
@@ -2,11 +2,12 @@ import {
   Entity,
   Column,
   CreateDateColumn,
-  DeleteDateColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
+import { Like } from './Like';
 import { User } from './User';
 
 @Entity()
@@ -40,4 +41,7 @@ export class Post {
 
   @Column({ nullable: true, name: 'deleted_at' })
   deletedAt: Date;
+
+  @OneToMany(() => Like, (like) => like.post)
+  like: Like[];
 }

--- a/src/entities/Post.ts
+++ b/src/entities/Post.ts
@@ -38,6 +38,6 @@ export class Post {
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 
-  @DeleteDateColumn({ name: 'deleted_at' })
+  @Column({ nullable: true, name: 'deleted_at' })
   deletedAt: Date;
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { Like } from './Like';
 import { Post } from './Post';
 import { Token } from './Token';
 
@@ -34,4 +35,7 @@ export class User {
 
   @OneToMany(() => Token, (token) => token.user)
   token: Token[];
+
+  @OneToMany(() => Like, (like) => like.user)
+  like: Like[];
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -46,14 +46,16 @@ export class PostController {
   }
 
   @Delete('/:id')
-  async deletePost(@Param('id') id: number) {
-    const status = await this.service.deletePost(id);
+  @UseGuards(AuthGuard('jwt'))
+  async deletePost(@Param('id') id: number, @GetUser() user: User) {
+    const status = await this.service.deletePost(id, user);
     return { status: status };
   }
 
   @Patch('/:id/restore')
-  async restorePost(@Param('id') id: number) {
-    const status = await this.service.restorePost(id);
+  @UseGuards(AuthGuard('jwt'))
+  async restorePost(@Param('id') id: number, @GetUser() user: User) {
+    const status = await this.service.restorePost(id, user);
     return { status: status };
   }
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -58,4 +58,11 @@ export class PostController {
     const status = await this.service.restorePost(id, user);
     return { status: status };
   }
+
+  @Get('/:id/like')
+  @UseGuards(AuthGuard('jwt'))
+  async likePost(@Param('id') id: number, @GetUser() user: User) {
+    const status = await this.service.likePost(id, user);
+    return { status: status };
+  }
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -41,16 +41,19 @@ export class PostController {
     @Body() postDto: PostDto,
     @GetUser() user: User,
   ) {
-    return await this.service.updatePost(id, postDto, user);
+    const status = await this.service.updatePost(id, postDto, user);
+    return { status: status };
   }
 
   @Delete('/:id')
   async deletePost(@Param('id') id: number) {
-    return await this.service.deletePost(id);
+    const status = await this.service.deletePost(id);
+    return { status: status };
   }
 
   @Patch('/:id/restore')
   async restorePost(@Param('id') id: number) {
-    return await this.service.restorePost(id);
+    const status = await this.service.restorePost(id);
+    return { status: status };
   }
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
@@ -25,8 +26,12 @@ export class PostController {
   }
 
   @Get()
-  async getAllPost() {
-    return await this.service.getAllPost();
+  async getAllPost(
+    @Query('order') order: string,
+    @Query('search') search: string,
+    @Query('tag') tag: string,
+  ) {
+    return await this.service.getAllPost(order, search, tag);
   }
 
   @Get('/:id')

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -3,9 +3,10 @@ import { PostController } from './post.controller';
 import { PostService } from './post.service';
 import { Post } from '../entities/Post';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Like } from '../entities/Like';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post])],
+  imports: [TypeOrmModule.forFeature([Post, Like])],
   controllers: [PostController],
   providers: [PostService],
 })

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -85,10 +85,12 @@ export class PostService {
   }
 
   async deletePost(id: number) {
-    await this.repository.softDelete({ id: id });
+    const result = await this.repository.softDelete({ id: id });
+    return result.affected === 1 ? '글 삭제 성공!' : '글 삭제 실패!';
   }
 
   async restorePost(id: number) {
-    await this.repository.restore({ id: id });
+    const result = await this.repository.restore({ id: id });
+    return result.affected === 1 ? '글 복구 성공!' : '글 복구 실패!';
   }
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -1,18 +1,23 @@
 import {
   BadRequestException,
+  ConsoleLogger,
   ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Like } from 'src/entities/Like';
 import { Post } from 'src/entities/Post';
-import { IsNull, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { User } from '../entities/User';
 import { PostDto } from './dto/post.dto';
 
 @Injectable()
 export class PostService {
-  constructor(@InjectRepository(Post) private repository: Repository<Post>) {}
+  constructor(
+    @InjectRepository(Post) private repository: Repository<Post>,
+    @InjectRepository(Like) private likeRepository: Repository<Like>,
+  ) {}
 
   async createPost(postDto: PostDto, user: User) {
     const { title, content, tag } = postDto;
@@ -31,7 +36,15 @@ export class PostService {
   async getAllPost() {
     const results = await this.repository
       .createQueryBuilder()
-      .select(['title', 'tag', 'created_at', 'likes', 'views', 'userId'])
+      .select([
+        'title',
+        'content',
+        'tag',
+        'created_at',
+        'likes',
+        'views',
+        'userId',
+      ])
       .where('deleted_at IS NULL')
       .getRawMany();
 
@@ -49,10 +62,10 @@ export class PostService {
 
     const result = await this.repository
       .createQueryBuilder()
-      .select()
+      .select(['title', 'tag', 'created_at', 'likes', 'views', 'userId'])
       .where('id = :id', { id: id })
       .andWhere('deleted_at IS NULL')
-      .getOne();
+      .getRawOne();
 
     if (!result) {
       throw new NotFoundException('해당 게시글을 찾을 수 없습니다.');
@@ -144,5 +157,61 @@ export class PostService {
       .where('post.id = :id', { id: id })
       .execute();
     return result.affected === 1 ? '글 복구 성공!' : '글 복구 실패!';
+  }
+
+  async likePost(id: number, user: User) {
+    // 해당 게시물 조회
+    const post = await this.repository
+      .createQueryBuilder('post')
+      .select()
+      .leftJoinAndSelect('post.user', 'user')
+      .where('post.id = :id', { id: id })
+      .andWhere('post.deleted_at IS NULL')
+      .getOne();
+
+    if (!post) {
+      throw new BadRequestException(
+        '해당 게시물을 찾을 수 없어 좋아요를 실패했습니다.',
+      );
+    }
+
+    const likeData = await this.likeRepository
+      .createQueryBuilder('like')
+      .leftJoinAndSelect('like.user', 'user')
+      .where('like.postId = :pid', { pid: id })
+      .andWhere('like.userId = :uid', { uid: user.id })
+      .getOne();
+
+    // 이미 해당 게시물에 좋아요를 누른경우 -> 좋아요 카운트 다운!
+    if (likeData) {
+      // 게시물 좋아요수 감소
+      await this.repository
+        .createQueryBuilder('post')
+        .update(Post)
+        .set({ likes: () => 'likes - 1' })
+        .where('post.id = :id', { id: id })
+        .execute();
+
+      // 좋아요 테이블에서 해당글 좋아요 정보 삭제
+      await this.likeRepository.delete(likeData.id);
+      return '글 좋아요 취소!';
+    }
+
+    // 테이블에 새로 정보 저장좋아요 -> 카운트 업!
+    const data = this.likeRepository.create({
+      post: { id: post.id },
+      user: { id: user.id },
+    });
+    await this.likeRepository.save(data);
+
+    const result = await this.repository
+      .createQueryBuilder('post')
+      .update(Post)
+      .set({ likes: () => 'likes + 1' })
+      .where('post.id = :id', { id: id })
+      .andWhere('post.deleted_at IS NULL')
+      .execute();
+
+    return result.affected === 1 ? '글 좋아요 성공!' : '글 좋아요 실패!';
   }
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -33,22 +33,46 @@ export class PostService {
     return await this.repository.save(post);
   }
 
-  async getAllPost() {
-    const results = await this.repository
-      .createQueryBuilder()
-      .select([
-        'title',
-        'content',
-        'tag',
-        'created_at',
-        'likes',
-        'views',
-        'userId',
-      ])
-      .where('deleted_at IS NULL')
-      .getRawMany();
+  async getAllPost(order: string, search: string, tag: string) {
+    if (!order && !search && !tag) {
+      // 따로 세부설정없이 전체 조회
+      const results = await this.repository
+        .createQueryBuilder()
+        .select([
+          'title',
+          'content',
+          'tag',
+          'created_at',
+          'likes',
+          'views',
+          'userId',
+        ])
+        .where('deleted_at IS NULL')
+        .getRawMany();
 
-    return results;
+      return results;
+    } else {
+      const results = await this.repository
+        .createQueryBuilder()
+        .select([
+          'title',
+          'content',
+          'tag',
+          'created_at',
+          'likes',
+          'views',
+          'userId',
+        ])
+        .where('deleted_at IS NULL')
+        .andWhere('title like :search', {
+          search: `%${search}%`,
+        })
+        .orderBy(`${order}`, 'DESC')
+        .getRawMany();
+
+      // .andWhere('tag in (:tag)', { tag: tag })
+      return results;
+    }
   }
 
   async getOnePost(id: number) {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -33,9 +33,9 @@ export class PostService {
     return await this.repository.save(post);
   }
 
-  async getAllPost(order: string, search: string, tag: string) {
+  async getAllPost(order = 'created_at', search: string, tag: string) {
     if (!order && !search && !tag) {
-      // 따로 세부설정없이 전체 조회
+      // 따로 세부설정없이 전체조회
       const results = await this.repository
         .createQueryBuilder()
         .select([
@@ -52,6 +52,7 @@ export class PostService {
 
       return results;
     } else {
+      // 정렬, 제목 검색, 해쉬태그 검색 일괄조건 전체조회
       const results = await this.repository
         .createQueryBuilder()
         .select([
@@ -67,10 +68,11 @@ export class PostService {
         .andWhere('title like :search', {
           search: `%${search}%`,
         })
-        .orderBy(`${order}`, 'DESC')
+        .andWhere('tag like :tag', { tag: `%#${tag}%` })
+        .orderBy(`${order}`, 'DESC') // 조회수, 좋아요수 정렬시 동일순위인경우 최신순 정렬
+        .addOrderBy('created_at', 'DESC')
         .getRawMany();
 
-      // .andWhere('tag in (:tag)', { tag: tag })
       return results;
     }
   }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -39,13 +39,21 @@ export class PostService {
   }
 
   async getOnePost(id: number) {
+    await this.repository
+      .createQueryBuilder()
+      .update(Post)
+      .set({ views: () => 'views + 1' })
+      .where('id = :id', { id: id })
+      .andWhere('deleted_at IS NULL')
+      .execute();
+
     const result = await this.repository
       .createQueryBuilder()
       .select()
       .where('id = :id', { id: id })
       .andWhere('deleted_at IS NULL')
-      .getRawOne();
-    console.log(result);
+      .getOne();
+
     if (!result) {
       throw new NotFoundException('해당 게시글을 찾을 수 없습니다.');
     }


### PR DESCRIPTION
## 설명
- 글 상세조회시 조회수 값 증가시키기 (횟수 무제한)
- 글 상세조회시 좋아요 (최초: 좋아요 상승, 이중: 좋아요 감소)
- 게시글 목록 조회시 정렬, 검색, 필터링 세부기능 추가하기 (정렬, 제목검색, 해쉬태그 일괄 조건 적용시 가능)

## 할일

- [x] 게시글 목록 조회시 정렬하기 (작성일, 조회수)
- [x] 글 상세조회시 좋아요, 조회수 값 증가시키기
- [x] 삭제시 상세조회, 목록조회 안되도록 설정하기
- [x] 삭제, 복구시 작성자 확인 & 이중삭제/복구 방지 에러리턴 추가

## 추후일정

> 7.27 ~ 7.31 2차 개발기간
- 목록 조회시 정렬/제목 키워드검색/해쉬태그 검색 개별 동작 가능 추가 
- 목록 조회시 페이지네이션 기능 추가
- 스웨거 작성
- 테스트코드 작성
